### PR TITLE
Support multiple input files through command line arguments

### DIFF
--- a/App/Context.cs
+++ b/App/Context.cs
@@ -75,7 +75,7 @@ public record Context(TextReader Reader, TextWriter Writer, bool TalkToUser)
     /// <param name="message">The message to be written.</param>
     public void Write(object message)
     {
-        if (TalkToUser) Writer.Write(message);
+        Writer.Write(message);
     }
 
     /// <summary>
@@ -84,7 +84,7 @@ public record Context(TextReader Reader, TextWriter Writer, bool TalkToUser)
     /// <param name="message">The message to be written.</param>
     public void WriteLine(object message)
     {
-        if (TalkToUser) Writer.WriteLine(message);
+        Writer.WriteLine(message);
     }
 
     /// <summary>

--- a/App/Program.cs
+++ b/App/Program.cs
@@ -33,7 +33,7 @@ public static class Program
             int FirstMinIndex = 0;
             int LastMaxIndex = 0;
 
-            for(int i = 0; i < arr.Count; i++)
+            for (int i = 0; i < arr.Count; i++)
             {
                 if (arr[i] < arr[FirstMinIndex])
                     FirstMinIndex = i;
@@ -43,7 +43,7 @@ public static class Program
 
             context.PrintLine($"max index: {LastMaxIndex}");
             context.PrintLine($"min index: {FirstMinIndex}");
-            
+
             if (FirstMinIndex > LastMaxIndex)
                 (FirstMinIndex, LastMaxIndex) = (LastMaxIndex, FirstMinIndex);
 


### PR DESCRIPTION
Any command line argument is now the path to a single task file.
The output file is now omitted, and the output-to-file statement from bash `>` should be used instead.